### PR TITLE
Bugfix/cartoee orientation

### DIFF
--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -129,7 +129,7 @@ def get_map(img_obj, proj=None, **kwargs):
     return ax
 
 
-def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None,crs="EPSG:4326"):
+def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None):
     """Add an Earth Engine image to a cartopy plot.
 
     args:
@@ -171,7 +171,7 @@ def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None,cr
             "or cartopy.mpl.geoaxes.GeoAxesSubplot"
         )
 
-    args = {"format": "png","crs":crs}
+    args = {"format": "png","crs":"EPSG:4326"}
     if region:
         args["region"] = map_region
     if dims:

--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -139,7 +139,6 @@ def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None):
         region (list | tuple, optional): geospatial region of the image to render in format [E,S,W,N]. By default, the whole image
         cmap (str, optional): string specifying matplotlib colormap to colorize image. If cmap is specified visParams cannot contain 'palette' key
         vis_params (dict, optional): visualization parameters as a dictionary. See https://developers.google.com/earth-engine/image_visualization for options
-        crs (str, optional): The projection to request the processed data in.
 
     returns:
         ax (cartopy.mpl.geoaxes.GeoAxesSubplot): cartopy GeoAxesSubplot object with Earth Engine results displayed

--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -129,7 +129,7 @@ def get_map(img_obj, proj=None, **kwargs):
     return ax
 
 
-def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None):
+def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None,crs="EPSG:4326"):
     """Add an Earth Engine image to a cartopy plot.
 
     args:
@@ -139,6 +139,7 @@ def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None):
         region (list | tuple, optional): geospatial region of the image to render in format [E,S,W,N]. By default, the whole image
         cmap (str, optional): string specifying matplotlib colormap to colorize image. If cmap is specified visParams cannot contain 'palette' key
         vis_params (dict, optional): visualization parameters as a dictionary. See https://developers.google.com/earth-engine/image_visualization for options
+        crs (str, optional): The projection to request the processed data in.
 
     returns:
         ax (cartopy.mpl.geoaxes.GeoAxesSubplot): cartopy GeoAxesSubplot object with Earth Engine results displayed
@@ -170,7 +171,7 @@ def add_layer(ax, img_obj, dims=1000, region=None, cmap=None, vis_params=None):
             "or cartopy.mpl.geoaxes.GeoAxesSubplot"
         )
 
-    args = {"format": "png"}
+    args = {"format": "png","crs":crs}
     if region:
         args["region"] = map_region
     if dims:


### PR DESCRIPTION
cartoee was producing plots with imagery being oriented wrongly, see #177. This was due to data being requested without a fixed spatial reference. This PR fixes the bug by adding the `crs` parameter when requesting  data from EE. 

It should be noted that the only CRS support for EE requests as of now is WGS84 (EPSG:4326). This is because it is the only CRS directly transferable to a `cartopy.crs` projection. This forces all of the EE computations in WGS84 which is not so ideal but allows the reprojections to cartopy crs be done locally with correct plotting.