### PR TITLE
Addressing Issue #472: Allow encoding to be specified in shp_to_ee

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -1110,7 +1110,7 @@ def ee_to_geojson(ee_object, out_json=None):
         print(e)
 
 
-def shp_to_geojson(in_shp, out_json=None):
+def shp_to_geojson(in_shp, out_json=None, **kwargs):
     """Converts a shapefile to GeoJSON.
 
     Args:
@@ -1153,7 +1153,10 @@ def shp_to_geojson(in_shp, out_json=None):
             except Exception as e:
                 raise Exception(e)
 
-        reader = shapefile.Reader(in_shp)
+        if 'encoding' in kwargs:
+            reader = shapefile.Reader(in_shp, encoding = kwargs.pop('encoding'))
+        else:
+            reader = shapefile.Reader(in_shp)
         out_dict = reader.__geo_interface__
         # fields = reader.fields[1:]
         # field_names = [field[0] for field in fields]
@@ -1192,7 +1195,7 @@ def shp_to_geojson(in_shp, out_json=None):
         raise Exception(e)
 
 
-def shp_to_ee(in_shp):
+def shp_to_ee(in_shp, **kwargs):
     """Converts a shapefile to Earth Engine objects. Note that the CRS of the shapefile must be EPSG:4326
 
     Args:
@@ -1203,7 +1206,10 @@ def shp_to_ee(in_shp):
     """
     # ee_initialize()
     try:
-        json_data = shp_to_geojson(in_shp)
+        if 'encoding' in kwargs:
+            json_data = shp_to_geojson(in_shp, encoding=kwargs.pop('encoding'))
+        else:
+            json_data = shp_to_geojson(in_shp)
         ee_object = geojson_to_ee(json_data)
         return ee_object
     except Exception as e:


### PR DESCRIPTION
This commit adds the ability for the user to specify encoding in shp_to_ee. It has been used repeatedly successfully by myself with several different datasets in various encodings, but has not been rigorously tested.
