### PR TITLE
The hover for countries didn't work

### DIFF
--- a/examples/notebooks/07_geojson.ipynb
+++ b/examples/notebooks/07_geojson.ipynb
@@ -149,7 +149,7 @@
     "    html1.value = '''\n",
     "        <h4>Country code: <b>{}</b></h4>\n",
     "        Country name: {}\n",
-    "    '''.format(feature['id'], feature['properties']['name'])\n",
+    "    '''.feature['properties']['ISO_A2'], feature['properties']['name'])\n",
     "\n",
     "json_layer.on_hover(update_html)"
    ]

--- a/examples/notebooks/07_geojson.ipynb
+++ b/examples/notebooks/07_geojson.ipynb
@@ -149,7 +149,7 @@
     "    html1.value = '''\n",
     "        <h4>Country code: <b>{}</b></h4>\n",
     "        Country name: {}\n",
-    "    '''.feature['properties']['ISO_A2'], feature['properties']['name'])\n",
+    "    '''.format(feature['properties']['ISO_A2'], feature['properties']['NAME'])\n",
     "\n",
     "json_layer.on_hover(update_html)"
    ]


### PR DESCRIPTION
feature['id'] doesn't work for ids of countries now, the data has been changed for it in data/countries.geojson. 

It works with the given change did here i.e. feature['properties']['ISO_A2'] or we can use feature['properties']['ISO_A3'], both gives us the id for the country.

Before:
![image](https://user-images.githubusercontent.com/72426535/134410163-548d03fa-071d-4a6b-847d-9d1918873384.png)

After:
https://watch.screencastify.com/v/ACkAlAVTpP4ZUQ2R0A7F