### PR TITLE
Add support for local raster datasets and remote COGs using localtileserver

### DIFF
--- a/docs/notebooks/83_local_tile.ipynb
+++ b/docs/notebooks/83_local_tile.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://binder.pangeo.io/badge_logo.svg)](https://gishub.org/geemap-pangeo)\n",
+    "\n",
+    "**Using local raster datasets or remote Cloud Optimized GeoTIFFs (COG) with leafmap**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) and [localtileserver](https://github.com/banesullivan/localtileserver) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install geemap localtileserver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify input raster datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = os.path.expanduser('~/Downloads')\n",
+    "\n",
+    "if not os.path.exists(out_dir):\n",
+    "    os.makedirs(out_dir)\n",
+    "\n",
+    "dem = os.path.join(out_dir, 'dem.tif')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download samples raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(dem):\n",
+    "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
+    "    geemap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add local raster datasets to the map. The available palettes can be found at https://jiffyclub.github.io/palettable/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add a remote Cloud Optimized GeoTIFF(COG) to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_remote_tile(url, layer_name=\"CA Fire\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Table of Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "313px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -94,3 +94,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 80. Adding a point layer with popup attributes (video | gif | [notebook](https://geemap.org/notebooks/80_point_layer))
 81. Creating timelapse animations from GEOS weather satellites (video | gif | [notebook](https://geemap.org/notebooks/81_goes_timelapse))
 82. Creating elevation contours for any location around the globe (video | gif | [notebook](https://geemap.org/notebooks/82_contours))
+83. Loading local raster datasets and Cloud Optimized GeoTIFF (COG) ([notebook](https://geemap.org/notebooks/83_local_tile))

--- a/examples/README.md
+++ b/examples/README.md
@@ -101,6 +101,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 80. Adding a point layer with popup attributes (video | gif | [notebook](https://geemap.org/notebooks/80_point_layer))
 81. Creating timelapse animations from GEOS weather satellites (video | gif | [notebook](https://geemap.org/notebooks/81_goes_timelapse))
 82. Creating elevation contours for any location around the globe (video | gif | [notebook](https://geemap.org/notebooks/82_contours))
+83. Loading local raster datasets and Cloud Optimized GeoTIFF (COG) ([notebook](https://geemap.org/notebooks/83_local_tile))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/83_local_tile.ipynb
+++ b/examples/notebooks/83_local_tile.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://binder.pangeo.io/badge_logo.svg)](https://gishub.org/geemap-pangeo)\n",
+    "\n",
+    "**Using local raster datasets or remote Cloud Optimized GeoTIFFs (COG) with leafmap**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) and [localtileserver](https://github.com/banesullivan/localtileserver) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install geemap localtileserver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify input raster datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = os.path.expanduser('~/Downloads')\n",
+    "\n",
+    "if not os.path.exists(out_dir):\n",
+    "    os.makedirs(out_dir)\n",
+    "\n",
+    "dem = os.path.join(out_dir, 'dem.tif')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download samples raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(dem):\n",
+    "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
+    "    geemap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add local raster datasets to the map. The available palettes can be found at https://jiffyclub.github.io/palettable/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add a remote Cloud Optimized GeoTIFF(COG) to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_remote_tile(url, layer_name=\"CA Fire\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Table of Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "313px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ matplotlib
 mss
 numpy
 owslib
+palettable
 pandas
 pillow
 pycrs


### PR DESCRIPTION
Built upon the amazing [localtileserver](https://github.com/banesullivan/localtileserver) package by @banesullivan, geemap now supports loading local raster dataset and remote Cloud Optimized GeoTIFF (COG) with only one line of code. 

It supports both the ipyleaflet and folium plotting backends. Use either `import geemap` or `import geemap.foliumap as geemap`. The remaining code stays the same. 

**Add a local raster dataset**
```python
import geemap
m = geemap.Map()
m.add_local_tile('dem.tif', palette='matplotlib.Viridis_10', layer_name="DEM")
m
```

**Add a remote COG**
```python
import geemap
m = geemap.Map()
url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'
m.add_remote_tile(url, layer_name="CA Fire")
m
```
Local tile:
![image](https://user-images.githubusercontent.com/5016453/143669185-e47cfde4-7c93-469a-b373-edfdb9b06322.png)

Remote COG:
![image](https://user-images.githubusercontent.com/5016453/143669211-a2d72ff8-8b47-43d9-9c10-af4cfe78b2a8.png)
