### PR TITLE
split_map defaults changed and ee_basemap references removed

### DIFF
--- a/geemap/basemaps.py
+++ b/geemap/basemaps.py
@@ -1,6 +1,6 @@
-"""Module for basemaps. Each basemap is defined as item in the ee_basemaps dictionary. For example, to access Google basemaps, use the following:
+"""Module for basemaps. Each basemap is defined as item in the basemaps dictionary. For example, to access Google basemaps, use the following:
 
-ee_basemaps['ROADMAP'], ee_basemaps['SATELLITE'], ee_basemaps['HYBRID'].
+basemaps['ROADMAP'], basemaps['SATELLITE'], basemaps['HYBRID'].
 
 More WMS basemaps can be found at the following websites:
 

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -1604,7 +1604,7 @@ class Map(ipyleaflet.Map):
         """Adds a basemap to the map.
 
         Args:
-            basemap (str, optional): Can be one of string from ee_basemaps. Defaults to 'HYBRID'.
+            basemap (str, optional): Can be one of string from basemaps. Defaults to 'HYBRID'.
         """
         try:
             if (
@@ -2283,12 +2283,12 @@ class Map(ipyleaflet.Map):
 
     addLayerControl = add_layer_control
 
-    def split_map(self, left_layer="HYBRID", right_layer="ESRI"):
+    def split_map(self, left_layer="HYBRID", right_layer="ROADMAP"):
         """Adds split map.
 
         Args:
             left_layer (str, optional): The layer tile layer. Defaults to 'HYBRID'.
-            right_layer (str, optional): The right tile layer. Defaults to 'ESRI'.
+            right_layer (str, optional): The right tile layer. Defaults to 'ROADMAP'.
         """
         try:
             controls = self.controls

--- a/geemap/heremap.py
+++ b/geemap/heremap.py
@@ -131,7 +131,7 @@ class Map(here_map_widget.Map):
         """Adds a basemap to the map.
 
         Args:
-            basemap (str, optional): Can be one of string from ee_basemaps. Defaults to 'HYBRID'.
+            basemap (str, optional): Can be one of string from basemaps. Defaults to 'HYBRID'.
         """
         import xyzservices
 


### PR DESCRIPTION
split_map() defaulted to the ESRI basemap for the right pane, which is no longer in the list of basemaps. The default for the right pane was changed to ROADMAP.

ee_basemaps is no longer. References to it in comments were removed. 