### PR TITLE
common.ee_export_image: print an exception message when ee_object.get…

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -1711,7 +1711,12 @@ def ee_export_image(
         if crs is not None:
             params["crs"] = crs
 
-        url = ee_object.getDownloadURL(params)
+        try:
+            url = ee_object.getDownloadURL(params)
+        except Exception as e:
+            print("An error occurred while downloading.")
+            print(e)
+            return
         print(f"Downloading data from {url}\nPlease wait ...")
         r = requests.get(url, stream=True)
 


### PR DESCRIPTION
`url = ee_object.getDownloadURL(params) ` can fail and throw an exception - "Total request size (xxxx) must be less than or equal to 50331648 bytes".  This exception message is useful and it's not output.
