### PR TITLE
Update get_image_collection_gif()

### DIFF
--- a/geemap/cartoee.py
+++ b/geemap/cartoee.py
@@ -1112,7 +1112,10 @@ def get_image_collection_gif(
             print(f"Downloading {i+1}/{count}: {name} ...")
 
         # Size plot
-        plt.figure(figsize=fig_size)
+        fig = plt.figure(figsize=fig_size)
+
+        # Set the facecolor
+        fig.patch.set_facecolor('white')
 
         # Plot image
         ax = get_map(image, region=region, vis_params=vis_params, cmap=cmap, proj=proj)
@@ -1133,7 +1136,7 @@ def get_image_collection_gif(
             add_north_arrow(ax, **north_arrow_dict)
 
         # Save plot
-        plt.savefig(fname=out_img, dpi=dpi_plot)
+        plt.savefig(fname=out_img, dpi=dpi_plot, bbox_inches='tight', facecolor=fig.get_facecolor())
 
         plt.clf()
         plt.close()


### PR DESCRIPTION
Transparency of images generated by the delta() function resulted in lower quality gif and video. This is resolved by setting face color (for example: white).

Before Modification
![animation_a](https://user-images.githubusercontent.com/61366166/152454102-20ba207b-46aa-4092-8c7d-4361b16835d7.gif)

After Modification
![animation_b](https://user-images.githubusercontent.com/61366166/152454118-eafc5e07-608d-4ba6-a76d-055754a18e2f.gif)

