### PR TITLE
Added support for choropleth maps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.4 - Apr 27, 2022
+
+**New Features**:
+
+-   Added support for creating interactive choropleth maps with a variety of classification schemes [#1043](https://github.com/giswqs/geemap/pull/1043)
+
 ## v0.13.3 - Apr 25, 2022
 
 **New Features**:

--- a/docs/notebooks/110_choropleth.ipynb
+++ b/docs/notebooks/110_choropleth.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4c367ae-0af4-4322-bd66-06f442fda626",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/101_choropleth.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/geemap-binder)\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f91ffa6-0819-4718-b376-c0b351d04e31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02460c7d-e507-46f9-aa1c-d1519c065c04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = geemap.examples.datasets.countries_geojson"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b50e3e2-cfba-47d2-b923-fa90e795a396",
+   "metadata": {},
+   "source": [
+    "Available classification schemes: \n",
+    "* BoxPlot\n",
+    "* EqualInterval\n",
+    "* FisherJenks\n",
+    "* FisherJenksSampled\n",
+    "* HeadTailBreaks\n",
+    "* JenksCaspall\n",
+    "* JenksCaspallForced\n",
+    "* JenksCaspallSampled\n",
+    "* MaxP\n",
+    "* MaximumBreaks\n",
+    "* NaturalBreaks\n",
+    "* Quantiles\n",
+    "* Percentiles\n",
+    "* StdMean\n",
+    "* UserDefined\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5561efa0-39b3-4722-bac4-609fc415a446",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data, column='POP_EST', scheme='Quantiles', cmap='Blues', legend_title='Population'\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf02d2d-b97e-440d-bf31-ffbc32f9eee2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='EqualInterval',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79406657-1517-447f-b179-e5d477d02cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='FisherJenks',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4c1907c-474e-4328-ae4b-75b04f7a6a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='JenksCaspall',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "_draft": {
+   "nbviewer_url": "https://gist.github.com/e6d4bd03250f489e9c1b5a8872ccf60c"
+  },
+  "gist": {
+   "data": {
+    "description": "choropleth maps",
+    "public": true
+   },
+   "id": "e6d4bd03250f489e9c1b5a8872ccf60c"
+  },
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -121,3 +121,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 107. Using the pydeck plotting backend ([notebook](https://geemap.org/notebooks/107_pydeck))
 108. Calculating zonal statistics with two images ([notebook](https://geemap.org/notebooks/108_image_zonal_stats))
 109. Creating coordinate grids with one line of code ([notebook](https://geemap.org/notebooks/109_coordinate_grids))
+110. Creating choropleth maps with a variety of classification schemes ([notebook](https://geemap.org/notebooks/110_choropleth))

--- a/examples/README.md
+++ b/examples/README.md
@@ -127,6 +127,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 107. Using the pydeck plotting backend ([notebook](https://geemap.org/notebooks/107_pydeck))
 108. Calculating zonal statistics with two images ([notebook](https://geemap.org/notebooks/108_image_zonal_stats))
 109. Creating coordinate grids with one line of code ([notebook](https://geemap.org/notebooks/109_coordinate_grids))
+110. Creating choropleth maps with a variety of classification schemes ([notebook](https://geemap.org/notebooks/110_choropleth))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/110_choropleth.ipynb
+++ b/examples/notebooks/110_choropleth.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4c367ae-0af4-4322-bd66-06f442fda626",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/101_choropleth.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/geemap-binder)\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f91ffa6-0819-4718-b376-c0b351d04e31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02460c7d-e507-46f9-aa1c-d1519c065c04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = geemap.examples.datasets.countries_geojson"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b50e3e2-cfba-47d2-b923-fa90e795a396",
+   "metadata": {},
+   "source": [
+    "Available classification schemes: \n",
+    "* BoxPlot\n",
+    "* EqualInterval\n",
+    "* FisherJenks\n",
+    "* FisherJenksSampled\n",
+    "* HeadTailBreaks\n",
+    "* JenksCaspall\n",
+    "* JenksCaspallForced\n",
+    "* JenksCaspallSampled\n",
+    "* MaxP\n",
+    "* MaximumBreaks\n",
+    "* NaturalBreaks\n",
+    "* Quantiles\n",
+    "* Percentiles\n",
+    "* StdMean\n",
+    "* UserDefined\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5561efa0-39b3-4722-bac4-609fc415a446",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data, column='POP_EST', scheme='Quantiles', cmap='Blues', legend_title='Population'\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf02d2d-b97e-440d-bf31-ffbc32f9eee2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='EqualInterval',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79406657-1517-447f-b179-e5d477d02cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='FisherJenks',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4c1907c-474e-4328-ae4b-75b04f7a6a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = geemap.Map()\n",
+    "m.add_data(\n",
+    "    data,\n",
+    "    column='POP_EST',\n",
+    "    scheme='JenksCaspall',\n",
+    "    cmap='Blues',\n",
+    "    legend_title='Population',\n",
+    ")\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "_draft": {
+   "nbviewer_url": "https://gist.github.com/e6d4bd03250f489e9c1b5a8872ccf60c"
+  },
+  "gist": {
+   "data": {
+    "description": "choropleth maps",
+    "public": true
+   },
+   "id": "e6d4bd03250f489e9c1b5a8872ccf60c"
+  },
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 
 import os
 

--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -5,7 +5,6 @@ __email__ = "giswqs@gmail.com"
 __version__ = "0.13.3"
 
 import os
-from . import examples
 
 
 def in_colab_shell():

--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -2,6 +2,7 @@ import os
 from .common import *
 from .osm import *
 from .geemap import basemaps
+from . import examples
 
 try:
     import pydeck as pdk

--- a/geemap/eefolium.py
+++ b/geemap/eefolium.py
@@ -9,6 +9,8 @@ from folium import plugins
 from .common import *
 from .conversion import *
 from .legends import builtin_legends
+from . import examples
+
 
 # More WMS basemaps can be found at https://viewer.nationalmap.gov/services/
 ee_basemaps = {

--- a/geemap/heremap.py
+++ b/geemap/heremap.py
@@ -18,6 +18,7 @@ from .common import (
     vector_to_geojson,
     random_string,
 )
+from . import examples
 
 try:
     import here_map_widget

--- a/geemap/kepler.py
+++ b/geemap/kepler.py
@@ -7,6 +7,7 @@ import pandas as pd
 from IPython.display import display, HTML
 from .common import *
 from .osm import *
+from . import examples
 
 try:
     import keplergl

--- a/geemap/plotlymap.py
+++ b/geemap/plotlymap.py
@@ -5,6 +5,8 @@ import ipywidgets as widgets
 from .basemaps import xyz_to_plotly
 from .common import *
 from .osm import *
+from . import examples
+
 
 try:
     import plotly.express as px

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,7 @@ nav:
           - notebooks/107_pydeck.ipynb
           - notebooks/108_image_zonal_stats.ipynb
           - notebooks/109_coordinate_grids.ipynb
+          - notebooks/110_choropleth.ipynb
           - miscellaneous:
                 - notebooks/cartoee_colab.ipynb
                 - notebooks/cartoee_colorbar.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ ipyfilechooser>=0.6.0
 ipyleaflet>=0.14.0
 ipytree
 jupyterlab>=3
+mapclassify>=2.4.0
 matplotlib
 numpy
 pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.3
+current_version = 0.13.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/giswqs/geemap",
-    version="0.13.3",
+    version="0.13.4",
     zip_safe=False,
 )


### PR DESCRIPTION
Built upon [mapclassify](https://pysal.org/mapclassify/), this PR adds support for creating choropleth maps with a variety of classification schemes with only one line of code. 

```python
allowed_schemes = [
    "BoxPlot",
    "EqualInterval",
    "FisherJenks",
    "FisherJenksSampled",
    "HeadTailBreaks",
    "JenksCaspall",
    "JenksCaspallForced",
    "JenksCaspallSampled",
    "MaxP",
    "MaximumBreaks",
    "NaturalBreaks",
    "Quantiles",
    "Percentiles",
    "StdMean",
    "UserDefined",
]
```

![](https://i.imgur.com/G325mz0.gif)