### PR TITLE
Add Renku Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ geemap
 .. image:: https://mybinder.org/badge_logo.svg
         :target: https://gishub.org/geemap-binder
 
+.. image:: https://renkulab.io/renku-badge.svg
+        :target: https://renkulab.io/projects/renku-stories/geemap/sessions/new?autostart=1
+
 .. image:: https://img.shields.io/pypi/v/geemap.svg
         :target: https://pypi.python.org/pypi/geemap
 


### PR DESCRIPTION
This PR proposes to add a "launch on renku" badge to the README.

Like Binder, [Renku](https://renkulab.io) provides interactive Jupyter sessions for users to try notebooks and code examples. In addition, Renku sessions are tied to a gitlab repository, so logged-in users can fork to modify the code and save their changes.

The badge starts a session from a Renku gitlab repository. When a session is started, it builds a docker image from the repository and launches a Jupyter Lab interface, where the user can test out the geemap package. The notebook that the Renku session launches is an adaptation of the geemap Google Colab tutorial.