### PR TITLE
Added cartoee basemap support #1067

### DIFF
--- a/docs/notebooks/112_cartoee_basemap.ipynb
+++ b/docs/notebooks/112_cartoee_basemap.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/112_cartoee_basemap.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) and [cartopy](https://scitools.org.uk/cartopy/docs/latest/installing.html#installing) if needed. Keep in mind that cartopy can be challenging to install. If you are unable to install cartopy on your computer, you can try Google Colab with this the [notebook example](https://colab.research.google.com/github/giswqs/geemap/blob/master/examples/notebooks/cartoee_colab.ipynb). \n",
+    "\n",
+    "See below the commands to install cartopy and geemap using conda/mamba:\n",
+    "\n",
+    "```\n",
+    "conda create -n gee python=3.9\n",
+    "conda activate gee\n",
+    "conda install mamba -c conda-forge\n",
+    "mamba install cartopy scipy -c conda-forge\n",
+    "mamba install geemap -c conda-forge\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pylab inline\n",
+    "\n",
+    "import ee\n",
+    "import geemap\n",
+    "\n",
+    "# import the cartoee functionality from geemap\n",
+    "from geemap import cartoee\n",
+    "import cartopy.io.img_tiles as cimgt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Earth Engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Earth Engine dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a landsat image to visualize\n",
+    "image = ee.Image('LANDSAT/LC08/C01/T1_SR/LC08_044034_20140318')\n",
+    "\n",
+    "# define the visualization parameters to view\n",
+    "vis = {\"bands\": ['B5', 'B4', 'B3'], \"min\": 0, \"max\": 5000, \"gamma\": 1.3}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Google basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap='ROADMAP', zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Stamen Terrain basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basemap = cimgt.StamenTerrain()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use OpenStreetMap basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basemap = cimgt.OSM()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use other basemaps\n",
+    "\n",
+    "For more basemaps, see https://scitools.org.uk/cartopy/docs/v0.19/cartopy/io/img_tiles.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib.transforms import offset_copy\n",
+    "import cartopy.crs as ccrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap='SATELLITE', zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "plt.plot(\n",
+    "    -122.4457,\n",
+    "    37.7574,\n",
+    "    marker='o',\n",
+    "    color='blue',\n",
+    "    markersize=10,\n",
+    "    alpha=0.7,\n",
+    "    transform=ccrs.Geodetic(),\n",
+    ")\n",
+    "\n",
+    "# Use the cartopy interface to create a matplotlib transform object\n",
+    "# for the Geodetic coordinate system. We will use this along with\n",
+    "# matplotlib's offset_copy function to define a coordinate system which\n",
+    "# translates the text by 25 pixels to the left.\n",
+    "geodetic_transform = ccrs.Geodetic()._as_mpl_transform(ax)\n",
+    "text_transform = offset_copy(geodetic_transform, units='dots', x=-25)\n",
+    "\n",
+    "plt.text(\n",
+    "    -122.4457,\n",
+    "    37.7574,\n",
+    "    u'San Francisco',\n",
+    "    verticalalignment='center',\n",
+    "    horizontalalignment='right',\n",
+    "    transform=text_transform,\n",
+    "    fontsize='large',\n",
+    "    fontweight='bold',\n",
+    "    color='white',\n",
+    "    bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'),\n",
+    ")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/Yw2N42R.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "toc-showcode": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/112_cartoee_basemap.ipynb
+++ b/docs/notebooks/112_cartoee_basemap.ipynb
@@ -232,15 +232,8 @@
     "# add the coastline\n",
     "ax.coastlines(color=\"yellow\")\n",
     "\n",
-    "plt.plot(\n",
-    "    -122.4457,\n",
-    "    37.7574,\n",
-    "    marker='o',\n",
-    "    color='blue',\n",
-    "    markersize=10,\n",
-    "    alpha=0.7,\n",
-    "    transform=ccrs.Geodetic(),\n",
-    ")\n",
+    "plt.plot(-122.4457, 37.7574, marker='o', color='blue', markersize=10,\n",
+    "         alpha=0.7, transform=ccrs.Geodetic())\n",
     "\n",
     "# Use the cartopy interface to create a matplotlib transform object\n",
     "# for the Geodetic coordinate system. We will use this along with\n",
@@ -249,18 +242,10 @@
     "geodetic_transform = ccrs.Geodetic()._as_mpl_transform(ax)\n",
     "text_transform = offset_copy(geodetic_transform, units='dots', x=-25)\n",
     "\n",
-    "plt.text(\n",
-    "    -122.4457,\n",
-    "    37.7574,\n",
-    "    u'San Francisco',\n",
-    "    verticalalignment='center',\n",
-    "    horizontalalignment='right',\n",
-    "    transform=text_transform,\n",
-    "    fontsize='large',\n",
-    "    fontweight='bold',\n",
-    "    color='white',\n",
-    "    bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'),\n",
-    ")\n",
+    "plt.text(-122.4457, 37.7574, u'San Francisco',\n",
+    "         verticalalignment='center', horizontalalignment='right',\n",
+    "         transform=text_transform, fontsize='large', fontweight='bold', color='white',\n",
+    "         bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'))\n",
     "\n",
     "show()"
    ]
@@ -270,6 +255,66 @@
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/Yw2N42R.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Global-scale maps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get an earth engine image of ocean data for Jan-Mar 2018\n",
+    "ocean = (\n",
+    "    ee.ImageCollection('NASA/OCEANDATA/MODIS-Terra/L3SMI')\n",
+    "    .filter(ee.Filter.date('2018-01-01', '2018-03-01'))\n",
+    "    .median()\n",
+    "    .select([\"sst\"], [\"SST\"])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set parameters for plotting\n",
+    "# will plot the Sea Surface Temp with specific range and colormap\n",
+    "visualization = {'bands': \"SST\", 'min': -2, 'max': 30}\n",
+    "# specify region to focus on\n",
+    "bbox = [180, -88, -180, 88]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# plot the result with cartoee using a PlateCarre projection (default)\n",
+    "ax = cartoee.get_map(ocean, cmap='plasma', vis_params=visualization, region=bbox, basemap='SATELLITE', zoom_level=2)\n",
+    "cb = cartoee.add_colorbar(ax, vis_params=visualization, loc='right', cmap='plasma')\n",
+    "\n",
+    "ax.set_title(label='Sea Surface Temperature', fontsize=15)\n",
+    "\n",
+    "ax.coastlines()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/brIuveC.png)"
    ]
   }
  ],

--- a/docs/notebooks/random_sampling.ipynb
+++ b/docs/notebooks/random_sampling.ipynb
@@ -25,7 +25,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(['B1', 'B2', 'B3', 'B4', 'B5', 'B7'])"
+    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(\n",
+    "    ['B1', 'B2', 'B3', 'B4', 'B5', 'B7']\n",
+    ")"
    ]
   },
   {

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -123,3 +123,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 109. Creating coordinate grids with one line of code ([notebook](https://geemap.org/notebooks/109_coordinate_grids))
 110. Creating choropleth maps with a variety of classification schemes ([notebook](https://geemap.org/notebooks/110_choropleth))
 111. Mapping the number of available satellite images for each pixel location ([notebook](https://geemap.org/notebooks/111_image_count))
+112. Adding basemaps to cartoee publication-quality maps ([notebook](https://geemap.org/notebooks/112_cartoee_basemap))

--- a/examples/README.md
+++ b/examples/README.md
@@ -129,6 +129,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 109. Creating coordinate grids with one line of code ([notebook](https://geemap.org/notebooks/109_coordinate_grids))
 110. Creating choropleth maps with a variety of classification schemes ([notebook](https://geemap.org/notebooks/110_choropleth))
 111. Mapping the number of available satellite images for each pixel location ([notebook](https://geemap.org/notebooks/111_image_count))
+112. Adding basemaps to cartoee publication-quality maps ([notebook](https://geemap.org/notebooks/112_cartoee_basemap))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/112_cartoee_basemap.ipynb
+++ b/examples/notebooks/112_cartoee_basemap.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/112_cartoee_basemap.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) and [cartopy](https://scitools.org.uk/cartopy/docs/latest/installing.html#installing) if needed. Keep in mind that cartopy can be challenging to install. If you are unable to install cartopy on your computer, you can try Google Colab with this the [notebook example](https://colab.research.google.com/github/giswqs/geemap/blob/master/examples/notebooks/cartoee_colab.ipynb). \n",
+    "\n",
+    "See below the commands to install cartopy and geemap using conda/mamba:\n",
+    "\n",
+    "```\n",
+    "conda create -n gee python=3.9\n",
+    "conda activate gee\n",
+    "conda install mamba -c conda-forge\n",
+    "mamba install cartopy scipy -c conda-forge\n",
+    "mamba install geemap -c conda-forge\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pylab inline\n",
+    "\n",
+    "import ee\n",
+    "import geemap\n",
+    "\n",
+    "# import the cartoee functionality from geemap\n",
+    "from geemap import cartoee\n",
+    "import cartopy.io.img_tiles as cimgt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Earth Engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Earth Engine dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a landsat image to visualize\n",
+    "image = ee.Image('LANDSAT/LC08/C01/T1_SR/LC08_044034_20140318')\n",
+    "\n",
+    "# define the visualization parameters to view\n",
+    "vis = {\"bands\": ['B5', 'B4', 'B3'], \"min\": 0, \"max\": 5000, \"gamma\": 1.3}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Google basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap='ROADMAP', zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Stamen Terrain basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basemap = cimgt.StamenTerrain()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use OpenStreetMap basemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basemap = cimgt.OSM()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use other basemaps\n",
+    "\n",
+    "For more basemaps, see https://scitools.org.uk/cartopy/docs/v0.19/cartopy/io/img_tiles.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib.transforms import offset_copy\n",
+    "import cartopy.crs as ccrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# use cartoee to get a map\n",
+    "ax = cartoee.get_map(image, vis_params=vis, basemap='SATELLITE', zoom_level=8)\n",
+    "\n",
+    "# pad the view for some visual appeal\n",
+    "cartoee.pad_view(ax)\n",
+    "\n",
+    "# add the gridlines and specify that the xtick labels be rotated 45 degrees\n",
+    "cartoee.add_gridlines(ax, interval=0.5, xtick_rotation=0, linestyle=\":\")\n",
+    "\n",
+    "# add the coastline\n",
+    "ax.coastlines(color=\"yellow\")\n",
+    "\n",
+    "plt.plot(\n",
+    "    -122.4457,\n",
+    "    37.7574,\n",
+    "    marker='o',\n",
+    "    color='blue',\n",
+    "    markersize=10,\n",
+    "    alpha=0.7,\n",
+    "    transform=ccrs.Geodetic(),\n",
+    ")\n",
+    "\n",
+    "# Use the cartopy interface to create a matplotlib transform object\n",
+    "# for the Geodetic coordinate system. We will use this along with\n",
+    "# matplotlib's offset_copy function to define a coordinate system which\n",
+    "# translates the text by 25 pixels to the left.\n",
+    "geodetic_transform = ccrs.Geodetic()._as_mpl_transform(ax)\n",
+    "text_transform = offset_copy(geodetic_transform, units='dots', x=-25)\n",
+    "\n",
+    "plt.text(\n",
+    "    -122.4457,\n",
+    "    37.7574,\n",
+    "    u'San Francisco',\n",
+    "    verticalalignment='center',\n",
+    "    horizontalalignment='right',\n",
+    "    transform=text_transform,\n",
+    "    fontsize='large',\n",
+    "    fontweight='bold',\n",
+    "    color='white',\n",
+    "    bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'),\n",
+    ")\n",
+    "\n",
+    "show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/Yw2N42R.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "toc-showcode": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/notebooks/112_cartoee_basemap.ipynb
+++ b/examples/notebooks/112_cartoee_basemap.ipynb
@@ -232,15 +232,8 @@
     "# add the coastline\n",
     "ax.coastlines(color=\"yellow\")\n",
     "\n",
-    "plt.plot(\n",
-    "    -122.4457,\n",
-    "    37.7574,\n",
-    "    marker='o',\n",
-    "    color='blue',\n",
-    "    markersize=10,\n",
-    "    alpha=0.7,\n",
-    "    transform=ccrs.Geodetic(),\n",
-    ")\n",
+    "plt.plot(-122.4457, 37.7574, marker='o', color='blue', markersize=10,\n",
+    "         alpha=0.7, transform=ccrs.Geodetic())\n",
     "\n",
     "# Use the cartopy interface to create a matplotlib transform object\n",
     "# for the Geodetic coordinate system. We will use this along with\n",
@@ -249,18 +242,10 @@
     "geodetic_transform = ccrs.Geodetic()._as_mpl_transform(ax)\n",
     "text_transform = offset_copy(geodetic_transform, units='dots', x=-25)\n",
     "\n",
-    "plt.text(\n",
-    "    -122.4457,\n",
-    "    37.7574,\n",
-    "    u'San Francisco',\n",
-    "    verticalalignment='center',\n",
-    "    horizontalalignment='right',\n",
-    "    transform=text_transform,\n",
-    "    fontsize='large',\n",
-    "    fontweight='bold',\n",
-    "    color='white',\n",
-    "    bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'),\n",
-    ")\n",
+    "plt.text(-122.4457, 37.7574, u'San Francisco',\n",
+    "         verticalalignment='center', horizontalalignment='right',\n",
+    "         transform=text_transform, fontsize='large', fontweight='bold', color='white',\n",
+    "         bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'))\n",
     "\n",
     "show()"
    ]
@@ -270,6 +255,66 @@
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/Yw2N42R.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Global-scale maps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get an earth engine image of ocean data for Jan-Mar 2018\n",
+    "ocean = (\n",
+    "    ee.ImageCollection('NASA/OCEANDATA/MODIS-Terra/L3SMI')\n",
+    "    .filter(ee.Filter.date('2018-01-01', '2018-03-01'))\n",
+    "    .median()\n",
+    "    .select([\"sst\"], [\"SST\"])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set parameters for plotting\n",
+    "# will plot the Sea Surface Temp with specific range and colormap\n",
+    "visualization = {'bands': \"SST\", 'min': -2, 'max': 30}\n",
+    "# specify region to focus on\n",
+    "bbox = [180, -88, -180, 88]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 10))\n",
+    "\n",
+    "# plot the result with cartoee using a PlateCarre projection (default)\n",
+    "ax = cartoee.get_map(ocean, cmap='plasma', vis_params=visualization, region=bbox, basemap='SATELLITE', zoom_level=2)\n",
+    "cb = cartoee.add_colorbar(ax, vis_params=visualization, loc='right', cmap='plasma')\n",
+    "\n",
+    "ax.set_title(label='Sea Surface Temperature', fontsize=15)\n",
+    "\n",
+    "ax.coastlines()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/brIuveC.png)"
    ]
   }
  ],

--- a/examples/notebooks/random_sampling.ipynb
+++ b/examples/notebooks/random_sampling.ipynb
@@ -25,7 +25,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(['B1', 'B2', 'B3', 'B4', 'B5', 'B7'])"
+    "image = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(\n",
+    "    ['B1', 'B2', 'B3', 'B4', 'B5', 'B7']\n",
+    ")"
    ]
   },
   {

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -2531,7 +2531,7 @@ def create_colorbar(
         heatmap.append(pair)
 
     def gaussian(x, a, b, c, d=0):
-        return a * math.exp(-((x - b) ** 2) / (2 * c ** 2)) + d
+        return a * math.exp(-((x - b) ** 2) / (2 * c**2)) + d
 
     def pixel(x, width=100, map=[], spread=1):
         width = float(width)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
           - notebooks/109_coordinate_grids.ipynb
           - notebooks/110_choropleth.ipynb
           - notebooks/111_image_count.ipynb
+          - notebooks/112_cartoee_basemap.ipynb
           - miscellaneous:
                 - notebooks/cartoee_colab.ipynb
                 - notebooks/cartoee_colorbar.ipynb


### PR DESCRIPTION
This PR improves the `cartoee.get_map()` function and adds two more parameters: `basemap` and `zoom_level`.
It support any basemaps that cartopy supports. See https://scitools.org.uk/cartopy/docs/v0.19/cartopy/io/img_tiles.html

@KMarkert @FeiYao-Edinburgh 

```python
# Use Google Basemaps
basemap = 'ROADMAP'  # 'SATELLITE', 'HYBRID', 'TERRAIN', 
ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)
```

```python
# Use any other basemaps that cartopy supports.
import cartopy.io.img_tiles as cimgt
basemap = cimgt.StamenTerrain() # cimgt.OSM(), etc.
ax = cartoee.get_map(image, vis_params=vis, basemap=basemap, zoom_level=8)
```

![](https://i.imgur.com/Yw2N42R.png)