### PR TITLE
Updated add_raster function

### DIFF
--- a/docs/notebooks/100_numpy_to_cog.ipynb
+++ b/docs/notebooks/100_numpy_to_cog.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,18 +53,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading https://github.com/giswqs/leafmap/raw/master/examples/data/cog.tif ...\n",
-      "Data downloaded to: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "geemap.download_from_url(url, in_cog)"
    ]
@@ -78,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,20 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(4, 206, 343)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "arr.shape"
    ]
@@ -114,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,20 +103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(206, 343)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ndvi.shape"
    ]
@@ -150,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,40 +128,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49b89169cb254d9aabe5f12fc09e18d2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = geemap.Map()\n",
     "m.add_raster(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",

--- a/docs/notebooks/100_numpy_to_cog.ipynb
+++ b/docs/notebooks/100_numpy_to_cog.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,9 +53,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading https://github.com/giswqs/leafmap/raw/master/examples/data/cog.tif ...\n",
+      "Data downloaded to: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif\n"
+     ]
+    }
+   ],
    "source": [
     "geemap.download_from_url(url, in_cog)"
    ]
@@ -69,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,9 +87,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4, 206, 343)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "arr.shape"
    ]
@@ -94,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,9 +123,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(206, 343)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ndvi.shape"
    ]
@@ -119,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,13 +159,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "49b89169cb254d9aabe5f12fc09e18d2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m = geemap.Map()\n",
-    "m.add_geotiff(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",
-    "m.add_geotiff(out_cog, palette=\"Greens\", layer_name=\"NDVI\")\n",
+    "m.add_raster(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",
+    "m.add_raster(out_cog, palette=\"Greens\", layer_name=\"NDVI\")\n",
     "m"
    ]
   },
@@ -163,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.9.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/104_clip_image.ipynb
+++ b/docs/notebooks/104_clip_image.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "m = geemap.Map()\n",
-    "m.add_geotiff(dem, palette='terrain', layer_name=\"DEM\")\n",
+    "m.add_raster(dem, palette='terrain', layer_name=\"DEM\")\n",
     "m"
    ]
   },
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_geotiff(output, palette='gist_earth', layer_name=\"Clip Image\")"
+    "m.add_raster(output, palette='gist_earth', layer_name=\"Clip Image\")"
    ]
   }
  ],

--- a/docs/notebooks/105_netcdf.ipynb
+++ b/docs/notebooks/105_netcdf.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "m = geemap.Map(layers_control=True)\n",
-    "m.add_geotiff(tif, band=[1], palette='coolwarm', layer_name='u_wind')\n",
+    "m.add_raster(tif, band=[1], palette='coolwarm', layer_name='u_wind')\n",
     "m.add_geojson(geojson, layer_name='Countries')\n",
     "m"
    ]

--- a/docs/notebooks/83_local_tile.ipynb
+++ b/docs/notebooks/83_local_tile.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,13 +60,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "if not os.path.exists(dem):\n",
     "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
-    "    geemap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+    "    geemap.download_file(dem_url, dem, unzip=False)"
    ]
   },
   {
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,9 +103,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa373e0e739d42b0babdbc98d97c5e49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[37.63046720520512, -119.03021877270292], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m"
    ]
@@ -119,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,9 +161,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "215e9762ebae4fdaa1f5f5966ec6d4ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m"
    ]

--- a/examples/notebooks/100_numpy_to_cog.ipynb
+++ b/examples/notebooks/100_numpy_to_cog.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,18 +53,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading https://github.com/giswqs/leafmap/raw/master/examples/data/cog.tif ...\n",
-      "Data downloaded to: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "geemap.download_from_url(url, in_cog)"
    ]
@@ -78,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,20 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(4, 206, 343)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "arr.shape"
    ]
@@ -114,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,20 +103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(206, 343)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ndvi.shape"
    ]
@@ -150,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,40 +128,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
-      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49b89169cb254d9aabe5f12fc09e18d2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = geemap.Map()\n",
     "m.add_raster(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",

--- a/examples/notebooks/100_numpy_to_cog.ipynb
+++ b/examples/notebooks/100_numpy_to_cog.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,9 +53,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading https://github.com/giswqs/leafmap/raw/master/examples/data/cog.tif ...\n",
+      "Data downloaded to: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif\n"
+     ]
+    }
+   ],
    "source": [
     "geemap.download_from_url(url, in_cog)"
    ]
@@ -69,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,9 +87,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4, 206, 343)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "arr.shape"
    ]
@@ -94,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,9 +123,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(206, 343)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ndvi.shape"
    ]
@@ -119,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,13 +159,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n",
+      "Warning 1: /media/hdd/Dropbox/git/geemap/examples/notebooks/cog.tif: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "49b89169cb254d9aabe5f12fc09e18d2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m = geemap.Map()\n",
-    "m.add_geotiff(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",
-    "m.add_geotiff(out_cog, palette=\"Greens\", layer_name=\"NDVI\")\n",
+    "m.add_raster(in_cog, band=[4, 1, 2], layer_name=\"Color infrared\")\n",
+    "m.add_raster(out_cog, palette=\"Greens\", layer_name=\"NDVI\")\n",
     "m"
    ]
   },
@@ -163,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.9.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/104_clip_image.ipynb
+++ b/examples/notebooks/104_clip_image.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "m = geemap.Map()\n",
-    "m.add_geotiff(dem, palette='terrain', layer_name=\"DEM\")\n",
+    "m.add_raster(dem, palette='terrain', layer_name=\"DEM\")\n",
     "m"
    ]
   },
@@ -173,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_geotiff(output, palette='gist_earth', layer_name=\"Clip Image\")"
+    "m.add_raster(output, palette='gist_earth', layer_name=\"Clip Image\")"
    ]
   }
  ],

--- a/examples/notebooks/105_netcdf.ipynb
+++ b/examples/notebooks/105_netcdf.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "m = geemap.Map(layers_control=True)\n",
-    "m.add_geotiff(tif, band=[1], palette='coolwarm', layer_name='u_wind')\n",
+    "m.add_raster(tif, band=[1], palette='coolwarm', layer_name='u_wind')\n",
     "m.add_geojson(geojson, layer_name='Countries')\n",
     "m"
    ]

--- a/examples/notebooks/83_local_tile.ipynb
+++ b/examples/notebooks/83_local_tile.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,13 +60,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "if not os.path.exists(dem):\n",
     "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
-    "    geemap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+    "    geemap.download_file(dem_url, dem, unzip=False)"
    ]
   },
   {
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,9 +103,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa373e0e739d42b0babdbc98d97c5e49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[37.63046720520512, -119.03021877270292], controls=(WidgetControl(options=['position', 'transparent…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m"
    ]
@@ -119,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,9 +161,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "215e9762ebae4fdaa1f5f5966ec6d4ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[20, 0], controls=(WidgetControl(options=['position', 'transparent_bg'], widget=HBox(children=(Togg…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "m"
    ]

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -620,7 +620,7 @@ class Map(folium.Map):
         tile.add_to(self)
         self.zoom_to_bounds(bounds)
 
-    add_geotiff = add_local_tile
+    add_raster = add_local_tile
 
     def add_remote_tile(
         self,

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -3413,7 +3413,7 @@ class Map(ipyleaflet.Map):
         self.add_layer(tile)
         self.zoom_to_bounds(bounds)
 
-    add_geotiff = add_local_tile
+    add_raster = add_local_tile
 
     def add_remote_tile(
         self,
@@ -3454,7 +3454,7 @@ class Map(ipyleaflet.Map):
         else:
             raise Exception("The source must be a URL.")
 
-    def add_raster(
+    def add_raster_legacy(
         self,
         image,
         bands=None,


### PR DESCRIPTION
The plotting backend of the `add_raster()` function has changed from `xarray-leaflet` to `localtileserver`. If you want to use the older version, use `add_raster_legacy()`.