### PR TITLE
Added Earth Engine support for pydeck

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.13.8 - Jun 5, 2022
+
+**New Features**:
+
+-   Added check_cmap function [#1084](https://github.com/giswqs/geemap/pull/1084)
+-   Added ESA and USGS basemaps [#1089](https://github.com/giswqs/geemap/pull/1089)
+-   Added Earth Engine support for pydeck [#1090](https://github.com/giswqs/geemap/pull/1090)
+
+**Improvement**:
+
+-   Fixed add local tile bug
+-   Fixed image_area_by_group bug
+-   Improved blend function
+-   Fixed links redirect
+-   Fixed basemap docs [#1075](https://github.com/giswqs/geemap/pull/1075)
+-   Upgraded add_raster function [#1083](https://github.com/giswqs/geemap/pull/1083)
+-   Fixed raster GUI band bug
+
 ## v0.13.7 - May 25, 2022
 
 **New Features**:

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -2531,7 +2531,7 @@ def create_colorbar(
         heatmap.append(pair)
 
     def gaussian(x, a, b, c, d=0):
-        return a * math.exp(-((x - b) ** 2) / (2 * c ** 2)) + d
+        return a * math.exp(-((x - b) ** 2) / (2 * c**2)) + d
 
     def pixel(x, width=100, map=[], spread=1):
         width = float(width)


### PR DESCRIPTION
This PR adds Earth Engine support for pydeck. 

```python
import ee
import geemap.deck as geemap

Map = geemap.Map()
dem = ee.Image('USGS/SRTMGL1_003')

vis_params = {
    'min': 0,
    'max': 4000,
    'palette': ['006633', 'E5FFCC', '662A00', 'D8D8D8', 'F5F5F5'],
}
Map.addLayer(dem, vis_params)

landsat7 = ee.Image('LANDSAT/LE7_TOA_5YEAR/1999_2003').select(
    ['B1', 'B2', 'B3', 'B4', 'B5', 'B7']
)
Map.addLayer(
    landsat7,
    {'bands': ['B4', 'B3', 'B2'], 'min': 20, 'max': 200, 'gamma': 2.0},
    'Landsat 7',
)

Map
```