### PR TITLE
Added support for Python 3.10

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -151,6 +151,7 @@ def ee_initialize(token_name="EARTHENGINE_TOKEN", auth_mode="notebook"):
         token_name (str, optional): The name of the Earth Engine token. Defaults to "EARTHENGINE_TOKEN".
         auth_mode (str, optional): The authentication mode, can be one of paste,notebook,gcloud,appdefault. Defaults to "notebook".
     """
+    import httplib2
 
     if ee.data._credentials is None:
         try:
@@ -184,10 +185,10 @@ def ee_initialize(token_name="EARTHENGINE_TOKEN", auth_mode="notebook"):
                     if is_drive_mounted():
                         copy_credentials_to_drive()
 
-            ee.Initialize()
+            ee.Initialize(http_transport=httplib2.Http())
         except Exception:
             ee.Authenticate(auth_mode=auth_mode)
-            ee.Initialize()
+            ee.Initialize(http_transport=httplib2.Http())
 
 
 def set_proxy(port=1080, ip="http://127.0.0.1", timeout=300):


### PR DESCRIPTION
`ee.Initialize()` does not work with Python 3.10. Here is a workaround. With this PR, users can continue to use `geemap.Map()` or `geemap.ee_initialize()` to initialize ee with Python 3.10. 

```python
import ee
import httplib2
ee.Authenticate(auth_mode='notebook')
ee.Initialize(http_transport=httplib2.Http())
```

Relevant issues:

- https://github.com/gee-community/qgis-earthengine-plugin/issues/109
- https://github.com/GoogleCloudPlatform/httplib2shim/pull/16
- https://groups.google.com/g/google-earth-engine-developers/c/hnNk9Iybmew/m/u8W8oXflBAAJ