### PR TITLE
Made mapclassify pkg optional

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -10685,12 +10685,18 @@ def classify(
         pd.DataFrame, dict: A pandas dataframe with the classification applied and a legend dictionary.
     """
 
-    import mapclassify
     import numpy as np
     import pandas as pd
     import geopandas as gpd
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+
+    try:
+        import mapclassify
+    except ImportError:
+        raise ImportError(
+            'mapclassify is required for this function. Install with "pip install mapclassify".'
+        )
 
     if isinstance(data, gpd.GeoDataFrame) or isinstance(data, pd.DataFrame):
         df = data

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ ipyfilechooser>=0.6.0
 ipyleaflet>=0.14.0
 ipytree
 jupyterlab>=3
-mapclassify>=2.4.0
 matplotlib
 numpy
 pandas
@@ -24,4 +23,3 @@ python-box
 sankee
 whiteboxgui>=0.6.0
 xyzservices
-

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ ipynb-py-convert
 ipyvtklink
 laspy
 localtileserver
+mapclassify>=2.4.0
 mss
 netcdf4
 palettable


### PR DESCRIPTION
This PR makes the mapclassify as an optional package to reduce the size of installed packages for geemap.