### PR TITLE
Update sankee to v0.1.0

### DIFF
--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -2657,77 +2657,48 @@ def sankee_gui(m=None):
 
     region.observe(region_changed, "value")
 
+    sankee_datasets = [
+        sankee.datasets.NLCD,
+        sankee.datasets.MODIS_LC_TYPE1,
+        sankee.datasets.CGLS_LC100,
+        sankee.datasets.LCMS_LU,
+        sankee.datasets.LCMS_LC,
+    ]
+    dataset_options = {dataset.name:dataset for dataset in sankee_datasets}
+    default_dataset = sankee_datasets[0]
+
     dataset = widgets.Dropdown(
-        options=[
-            "NLCD - National Land Cover Database",
-            "MCD12Q1 - MODIS Global Land Cover",
-            "CGLS - Copernicus Global Land Cover",
-            "LCMS - Land Change Monitoring System",
-        ],
-        value="NLCD - National Land Cover Database",
+        options=dataset_options.keys(),
+        value=default_dataset.name,
         description="Dataset:",
         layout=widgets.Layout(width=widget_width, padding=padding),
         style={"description_width": "initial"},
     )
 
-    NLCD_options = ["2001", "2004", "2006", "2008", "2011", "2013", "2016"]
-    MODIS_options = [str(y) for y in range(2001, 2020)]
-    CGLS_options = [str(y) for y in range(2015, 2020)]
-    LCMS_options = [str(y) for y in range(1985, 2021)]
-
     before = widgets.Dropdown(
-        options=NLCD_options,
-        value="2001",
+        options=default_dataset.years,
+        value=default_dataset.years[0],
         description="Before:",
         layout=widgets.Layout(width="123px", padding=padding),
         style={"description_width": "initial"},
     )
 
     after = widgets.Dropdown(
-        options=NLCD_options,
-        value="2016",
+        options=default_dataset.years,
+        value=default_dataset.years[-1],
         description="After:",
         layout=widgets.Layout(width="123px", padding=padding),
         style={"description_width": "initial"},
     )
 
     def dataset_changed(change):
-        if change["new"] == "NLCD - National Land Cover Database":
-            before.options = NLCD_options
-            after.options = NLCD_options
-            before.value = NLCD_options[0]
-            after.value = NLCD_options[-1]
-        elif change["new"] == "MCD12Q1 - MODIS Global Land Cover":
-            before.options = MODIS_options
-            after.options = MODIS_options
-            before.value = MODIS_options[0]
-            after.value = MODIS_options[-1]
-        elif change["new"] == "CGLS - Copernicus Global Land Cover":
-            before.options = CGLS_options
-            after.options = CGLS_options
-            before.value = CGLS_options[0]
-            after.value = CGLS_options[-1]
-        elif change["new"] == "LCMS - Land Change Monitoring System":
-            before.options = LCMS_options
-            after.options = LCMS_options
-            before.value = LCMS_options[0]
-            after.value = LCMS_options[-1]
+        selected = dataset_options[change["new"]]
+        before.options = selected.years
+        after.options = selected.years
+        before.value = selected.years[0]
+        after.value = selected.years[-1]
 
     dataset.observe(dataset_changed, "value")
-
-    dataset_template = {
-        "NLCD - National Land Cover Database": sankee.datasets.NLCD2016,
-        "MCD12Q1 - MODIS Global Land Cover": sankee.datasets.MODIS_LC_TYPE1,
-        "CGLS - Copernicus Global Land Cover": sankee.datasets.CGLS_LC100,
-        "LCMS - Land Change Monitoring System": sankee.datasets.LCMS_LC,
-    }
-
-    band_name = {
-        "NLCD - National Land Cover Database": "landcover",
-        "MCD12Q1 - MODIS Global Land Cover": "LC_Type1",
-        "CGLS - Copernicus Global Land Cover": "discrete_classification",
-        "LCMS - Land Change Monitoring System": "Land_Cover",
-    }
 
     samples = widgets.IntText(
         value=1000,
@@ -2992,62 +2963,12 @@ def sankee_gui(m=None):
                 print("Running ...")
 
             if m is not None:
-                exclude_classes = []
+                selected = dataset_options[dataset.value]
+                before_year = before.value
+                after_year = after.value
 
-                if "NLCD" in dataset.value:
-                    before_img = ee.Image(f"USGS/NLCD/NLCD{before.value}")
-                    after_img = ee.Image(f"USGS/NLCD/NLCD{after.value}")
-                    vis_params = {}
-                elif "MODIS" in dataset.value:
-                    before_img = ee.Image(f"MODIS/006/MCD12Q1/{before.value}_01_01")
-                    after_img = ee.Image(f"MODIS/006/MCD12Q1/{after.value}_01_01")
-                    vis_params = {
-                        "min": 1.0,
-                        "max": 17.0,
-                        "palette": [
-                            "05450a",
-                            "086a10",
-                            "54a708",
-                            "78d203",
-                            "009900",
-                            "c6b044",
-                            "dcd159",
-                            "dade48",
-                            "fbff13",
-                            "b6ff05",
-                            "27ff87",
-                            "c24f44",
-                            "a5a5a5",
-                            "ff6d4c",
-                            "69fff8",
-                            "f9ffa4",
-                            "1c0dff",
-                        ],
-                    }
-                elif "CGLS" in dataset.value:
-                    before_img = ee.Image(
-                        f"COPERNICUS/Landcover/100m/Proba-V-C3/Global/{before.value}"
-                    )
-                    after_img = ee.Image(
-                        f"COPERNICUS/Landcover/100m/Proba-V-C3/Global/{after.value}"
-                    )
-                    vis_params = {}
-                elif "LCMS" in dataset.value:
-                    before_img = ee.Image(
-                        f"USFS/GTAC/LCMS/v2020-5/LCMS_CONUS_v2020-5_{before.value}"
-                    )
-                    after_img = ee.Image(
-                        f"USFS/GTAC/LCMS/v2020-5/LCMS_CONUS_v2020-5_{after.value}"
-                    )
-                    vis_params = {}
-                    # LCMS Land Cover class 15 is a no data mask and should be excluded
-                    exclude_classes.append(15)
-
-                img_list = [before_img, after_img]
-                label_list = [before.value, after.value]
-
-                image1 = before_img.select(band_name[dataset.value])
-                image2 = after_img.select(band_name[dataset.value])
+                image1 = selected.get_year(before_year)
+                image2 = selected.get_year(after_year)
 
                 if region.value != "User-drawn ROI" or (
                     region.value == "User-drawn ROI" and m.user_roi is not None
@@ -3076,15 +2997,12 @@ def sankee_gui(m=None):
                     else:
                         plot_title = None
                     m.default_style = {"cursor": "wait"}
-                    plot = sankee.sankify(
-                        img_list,
-                        geom,
-                        label_list,
-                        dataset_template[dataset.value],
+                    plot = selected.sankify(
+                        years=[before_year, after_year],
+                        region=geom,
                         max_classes=classes.value,
                         n=int(samples.value),
-                        title=plot_title,
-                        exclude=exclude_classes,
+                        title=plot_title
                     )
 
                     output.clear_output()
@@ -3114,8 +3032,8 @@ def sankee_gui(m=None):
                         display(plot)
 
                     m.sankee_plot = plot
-                    m.addLayer(image1, vis_params, before.value)
-                    m.addLayer(image2, vis_params, after.value)
+                    m.addLayer(image1, {}, str(before_year))
+                    m.addLayer(image2, {}, str(after_year))
                     m.default_style = {"cursor": "default"}
 
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ pillow
 pycrs
 pyshp>=2.1.3
 python-box
-sankee
+sankee>=0.1.0
 whiteboxgui>=0.6.0
 xyzservices


### PR DESCRIPTION
Hi @giswqs, this was originally just updating LCMS (#517), but I ended up making larger changes to `sankee` released in [v0.1.0](https://github.com/aazuspan/sankee/releases/tag/v0.1.0). This PR updates all the sankee code to use the newer features, which dramatically simplifies things on the `geemap` side. All of the dataset parameters, year ranges, excluded no-data values, etc. are now pulled from `sankee`, so those can be updated without requiring a PR here. If a new dataset is added to `sankee`, it will only take 1 line of code to add support to `geemap`.

The v0.1.0 release has some [breaking changes](https://github.com/aazuspan/sankee/releases/tag/v0.1.0), so I also pinned the requirements. However, if someone intentionally downloads an older version of `geemap`, they may end up with the incompatible newer version of `sankee`. I added [an error](https://github.com/aazuspan/sankee/blob/22302cd375f1661f67bcfae361bb41f253b40bac/sankee/core.py#L83-L87) telling users to update if that happens, but I wanted to give you a heads up.

The `geemap` conda forge feedstock should be updated to pin `sankee>=0.1.0` as well. I can make a PR on the feedstock if you want.

Let me know if you have any changes!