### PR TITLE
Added support for changing geojson layer opacity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ geocoder
 geojson
 ipyevents
 ipyfilechooser>=0.6.0
-ipyleaflet>=0.14.0
+ipyleaflet>=0.17.0
 ipytree
 jupyterlab>=3
 matplotlib


### PR DESCRIPTION
Thanks to ipyleaflet v0.17.0, leafmap now supports changing GeoJSON layer visibility and opacity interactively. 


```python
import geemap
m = geemap.Map()
m.add_basemap("CartoDB.DarkMatter")
in_geojson = 'https://raw.githubusercontent.com/giswqs/geemap/master/examples/data/cable-geo.geojson'
callback = lambda feat: {"color": "#" + feat["properties"]["color"], "weight": 2}
m.add_geojson(in_geojson, layer_name="Cable lines", style_callback=callback, info_mode=None)
m
```

![Peek 2022-07-08 14-57](https://user-images.githubusercontent.com/5016453/178054211-a6d1f6d0-82ff-4924-ac73-c71f0ddbcdfe.gif)

