### PR TITLE
Added OEEL notebook example

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.15.1 - Jul 8, 2022
+
+**New Features**:
+
+-   Added support for Open Earth Engine Library (OEEL) #1137
+
 ## v0.15.0 - Jul 8, 2022
 
 **New Features**:

--- a/docs/notebooks/120_javascript.ipynb
+++ b/docs/notebooks/120_javascript.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f213685d-a844-4dae-8f85-56b4c860cbe0",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/120_javascript.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/geemap-binder)\n",
+    "\n",
+    "**Calling functions in Earth Engine JavaScript libraries from Python**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4a5ebbe-7382-4ebd-b8c7-72342fda809b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32e22cba-dedc-41c0-ad71-23efd4ad109b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c75079-227b-41e9-9de8-4f63b559488b",
+   "metadata": {},
+   "source": [
+    "Use the [Open Earth Engine Library (OEEL)](https://www.open-geocomputing.org/OpenEarthEngineLibrary/#)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3b590-2f41-4d55-9dde-311246167554",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2c8dfca-2117-4342-a569-0c7769208f28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ic = ee.ImageCollection(\"COPERNICUS/S2_SR\")\n",
+    "\n",
+    "icSize = (\n",
+    "    lib.Algorithms.Sentinel2.cloudfree(maxCloud=20, S2Collection=ic)\n",
+    "    .filterDate('2020-01-01', '2020-01-02')\n",
+    "    .size()\n",
+    ")\n",
+    "print('Cloud free imagery: ', icSize.getInfo())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149a18b2-3c53-427c-8b98-17248fa3330c",
+   "metadata": {},
+   "source": [
+    "Use an Earth Engine JavaScript library from a HTTP URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6157fac-15c5-4016-b24e-3729960e6844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://github.com/giswqs/geemap/blob/master/examples/javascripts/grid.js'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e385a13-e422-47ab-9231-a557e6107ca3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4f9427d-7a14-4433-8964-2e726c2b8375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ead5554-7df6-4233-957d-1db17bf656fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = lib.generateGrid(-180, -50, 180, 50, 10, 10, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "103ce65e-6dc2-4309-9cc8-e7374bf57af3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map.addLayer(grid, {}, 'Grid')\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c54aeb-763a-4f35-b024-49bf0f4275a1",
+   "metadata": {},
+   "source": [
+    "Use a local Earth Engine JavaScript library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc5da96b-d9f7-4042-b21c-1aed2be24d8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2afecc83-5fce-4ccc-8329-cd22eb212b48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS('grid.js', Map)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15bedb71-b098-4470-9b10-e074f69a2841",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "842cf18c-da16-443b-9d6b-fe43a3cb72bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.grid_test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8e1bb0f-bd5e-4ac2-9bea-ef755cbbf28c",
+   "metadata": {},
+   "source": [
+    "Use an Earth Engine JavaScript from an Earth Engine repo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec85798-b34f-4f67-88ef-73626204fd1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS('users/gena/packages:grid')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efe2eeb4-9a72-48c5-83f7-e0d6842683c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53c3f19c-6776-4a53-9f73-66a7fafca58c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = lib.generateGrid(-180, -50, 180, 50, 10, 10, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95a9c12e-a2ba-4c36-b759-30575b50eb0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map.addLayer(grid, {}, 'Grid')\n",
+    "Map"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -131,3 +131,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 117. Creating a fishnet based on an input vector dataset ([notebook](https://geemap.org/notebooks/117_fishnet))
 118. Downloading images directly to a local computer ([notebook](https://geemap.org/notebooks/118_download_image))
 119. Plotting raster data in 3D without only one line of code ([notebook](https://geemap.org/notebooks/119_plot_raster))
+120. Calling functions in Earth Engine JavaScript libraries from Python ([notebook](https://geemap.org/notebooks/120_javascript))

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,6 +137,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 117. Creating a fishnet based on an input vector dataset ([notebook](https://geemap.org/notebooks/117_fishnet))
 118. Downloading images directly to a local computer ([notebook](https://geemap.org/notebooks/118_download_image))
 119. Plotting raster data in 3D without only one line of code ([notebook](https://geemap.org/notebooks/119_plot_raster))
+120. Calling functions in Earth Engine JavaScript libraries from Python ([notebook](https://geemap.org/notebooks/120_javascript))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/javascripts/grid.js
+++ b/examples/javascripts/grid.js
@@ -68,7 +68,10 @@ var generateGrid = function(xmin, ymin, xmax, ymax, dx, dy, marginx, marginy, op
 var grid_test = function() {
 
     var gridVector = generateGrid(-180, -50, 180, 50, 10, 10, 0, 0)
-    Map.addLayer(gridVector, {}, 'grid vector')
+    Map.addLayer(gridVector, {}, 'Grid vector')
+
+    var gridRaster = generateRasterGrid(ee.Geometry.Point(0, 0), 10, 10, ee.Projection('EPSG:4326'))
+    Map.addLayer(gridRaster.select('id').randomVisualizer(), {}, 'Grid raster')
 
 }
 

--- a/examples/notebooks/120_javascript.ipynb
+++ b/examples/notebooks/120_javascript.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f213685d-a844-4dae-8f85-56b4c860cbe0",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/120_javascript.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/geemap-binder)\n",
+    "\n",
+    "**Calling functions in Earth Engine JavaScript libraries from Python**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4a5ebbe-7382-4ebd-b8c7-72342fda809b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32e22cba-dedc-41c0-ad71-23efd4ad109b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c75079-227b-41e9-9de8-4f63b559488b",
+   "metadata": {},
+   "source": [
+    "Use the [Open Earth Engine Library (OEEL)](https://www.open-geocomputing.org/OpenEarthEngineLibrary/#)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3b590-2f41-4d55-9dde-311246167554",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2c8dfca-2117-4342-a569-0c7769208f28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ic = ee.ImageCollection(\"COPERNICUS/S2_SR\")\n",
+    "\n",
+    "icSize = (\n",
+    "    lib.Algorithms.Sentinel2.cloudfree(maxCloud=20, S2Collection=ic)\n",
+    "    .filterDate('2020-01-01', '2020-01-02')\n",
+    "    .size()\n",
+    ")\n",
+    "print('Cloud free imagery: ', icSize.getInfo())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149a18b2-3c53-427c-8b98-17248fa3330c",
+   "metadata": {},
+   "source": [
+    "Use an Earth Engine JavaScript library from a HTTP URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6157fac-15c5-4016-b24e-3729960e6844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://github.com/giswqs/geemap/blob/master/examples/javascripts/grid.js'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e385a13-e422-47ab-9231-a557e6107ca3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4f9427d-7a14-4433-8964-2e726c2b8375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ead5554-7df6-4233-957d-1db17bf656fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = lib.generateGrid(-180, -50, 180, 50, 10, 10, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "103ce65e-6dc2-4309-9cc8-e7374bf57af3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map.addLayer(grid, {}, 'Grid')\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c54aeb-763a-4f35-b024-49bf0f4275a1",
+   "metadata": {},
+   "source": [
+    "Use a local Earth Engine JavaScript library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc5da96b-d9f7-4042-b21c-1aed2be24d8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2afecc83-5fce-4ccc-8329-cd22eb212b48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS('grid.js', Map)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15bedb71-b098-4470-9b10-e074f69a2841",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "842cf18c-da16-443b-9d6b-fe43a3cb72bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.grid_test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8e1bb0f-bd5e-4ac2-9bea-ef755cbbf28c",
+   "metadata": {},
+   "source": [
+    "Use an Earth Engine JavaScript from an Earth Engine repo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec85798-b34f-4f67-88ef-73626204fd1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib = geemap.requireJS('users/gena/packages:grid')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efe2eeb4-9a72-48c5-83f7-e0d6842683c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lib.availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53c3f19c-6776-4a53-9f73-66a7fafca58c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = lib.generateGrid(-180, -50, 180, 50, 10, 10, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95a9c12e-a2ba-4c36-b759-30575b50eb0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map = geemap.Map()\n",
+    "Map.addLayer(grid, {}, 'Grid')\n",
+    "Map"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
           - notebooks/117_fishnet.ipynb
           - notebooks/118_download_image.ipynb
           - notebooks/119_plot_raster.ipynb
+          - notebooks/120_javascript.ipynb
           - miscellaneous:
                 - notebooks/cartoee_colab.ipynb
                 - notebooks/cartoee_colorbar.ipynb


### PR DESCRIPTION
This PR adds a notebook example for using the [Open Earth Engine Library (OEEL)](https://www.open-geocomputing.org/OpenEarthEngineLibrary/#).  

@mgravey, geemap now supports OEEL. https://github.com/giswqs/geemap/pull/1137