### PR TITLE
use json to parse the gee credentials

### DIFF
--- a/examples/heroku/config_vars.py
+++ b/examples/heroku/config_vars.py
@@ -19,7 +19,7 @@ def set_heroku_vars(token_name="EARTHENGINE_TOKEN"):
             print("The credentials file does not exist.")
         else:
             with open(ee_token_file) as f:
-                content = json.load(f.read())
+                content = json.loads(f.read())
                 token = content["access_token"]
                 secret = "{}={}".format(token_name, token)
                 if platform.system() == "Windows":

--- a/examples/heroku/config_vars.py
+++ b/examples/heroku/config_vars.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from subprocess import DEVNULL, STDOUT, check_call
+import json
 
 
 def set_heroku_vars(token_name="EARTHENGINE_TOKEN"):
@@ -18,12 +19,8 @@ def set_heroku_vars(token_name="EARTHENGINE_TOKEN"):
             print("The credentials file does not exist.")
         else:
             with open(ee_token_file) as f:
-                content = f.read()
-                token = content.split(":")[1].strip()[1:-2]
-                # if platform.system() == 'Linux':
-                #     token = content.split(':')[1][1:-3]
-                # else:
-                #     token = content.split(':')[1][2:-2]
+                content = json.load(f.read())
+                token = content["access_token"]
                 secret = "{}={}".format(token_name, token)
                 if platform.system() == "Windows":
                     check_call(


### PR DESCRIPTION
In the heroku binding example, the first step is to load the earthengine_token from the loaded credentials. 
I wanted to try your code and it was working on my environment as I'm still using earthengine-api 0.1.270. My colleague that is using 0.1.317 has a completely different credential file structure so the loaded keys is meaningless.

This PR is an attempt to solve this by: 
- don't rely on file key order 
- don't use arbitrary slicing to find the key 
- use json to raise an error if the token key is missing

I cannot install a more recent version on my system so let me know if it works from your side !