### PR TITLE
Importing basemaps from geemap

### DIFF
--- a/docs/workshops/GeoPython_2021.ipynb
+++ b/docs/workshops/GeoPython_2021.ipynb
@@ -140,7 +140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from geemap.basemaps import basemaps"
+    "from geemap import basemaps"
    ]
   },
   {


### PR DESCRIPTION
Using "from geemaps.basemaps import basemaps" yields an error because "basemaps" has no child "basemaps"