### PR TITLE
zonal_stats: additions to allowed_statistics 

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6667,7 +6667,6 @@ def zonal_stats(
 
     allowed_statistics = {
         "COUNT": ee.Reducer.count(),
-        "COUNT_EVERY": ee.Reducer.countEvery(),
         "MEAN": ee.Reducer.mean(),
         "MAXIMUM": ee.Reducer.max(),
         "MEDIAN": ee.Reducer.median(),
@@ -6682,7 +6681,7 @@ def zonal_stats(
         ),
         "FIXED_HIST": ee.Reducer.fixedHistogram(hist_min, hist_max, hist_steps),
         "COMBINED_MEAN_COUNT": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True),
-        "COMBINED_MEAN_COUNT_COUNT_EVERY": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True).combine(ee.Reducer.countEvery(), sharedInputs=True),
+        "COMBINED_COUNT_MEAN": ee.Reducer.count().combine(ee.Reducer.mean(), sharedInputs=True),
     }
 
     if not (statistics_type.upper() in allowed_statistics.keys()):

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6681,7 +6681,6 @@ def zonal_stats(
             maxBuckets=max_buckets, minBucketWidth=min_bucket_width, maxRaw=max_raw
         ),
         "FIXED_HIST": ee.Reducer.fixedHistogram(hist_min, hist_max, hist_steps),
-        "COMBINED_MEAN_COUNT": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True),
         "COMBINED_COUNT_MEAN": ee.Reducer.count().combine(ee.Reducer.mean(), sharedInputs=True),
         "COMBINED_COUNT_MEAN_UNWEIGHTED": ee.Reducer.count().combine(ee.Reducer.mean().unweighted(), sharedInputs=True),
     }

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6681,6 +6681,8 @@ def zonal_stats(
             maxBuckets=max_buckets, minBucketWidth=min_bucket_width, maxRaw=max_raw
         ),
         "FIXED_HIST": ee.Reducer.fixedHistogram(hist_min, hist_max, hist_steps),
+        "COMBINED_MEAN_COUNT": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True),
+        "COMBINED_MEAN_COUNT_COUNT_EVERY": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True).combine(ee.Reducer.countEvery(), sharedInputs=True),
     }
 
     if not (statistics_type.upper() in allowed_statistics.keys()):

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6666,6 +6666,8 @@ def zonal_stats(
         return
 
     allowed_statistics = {
+        "COUNT": ee.Reducer.count(),
+        "COUNT_EVERY": ee.Reducer.countEvery(),
         "MEAN": ee.Reducer.mean(),
         "MAXIMUM": ee.Reducer.max(),
         "MEDIAN": ee.Reducer.median(),

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6668,6 +6668,7 @@ def zonal_stats(
     allowed_statistics = {
         "COUNT": ee.Reducer.count(),
         "MEAN": ee.Reducer.mean(),
+        "MEAN_UNWEIGHTED": ee.Reducer.mean().unweighted(),
         "MAXIMUM": ee.Reducer.max(),
         "MEDIAN": ee.Reducer.median(),
         "MINIMUM": ee.Reducer.min(),
@@ -6682,6 +6683,7 @@ def zonal_stats(
         "FIXED_HIST": ee.Reducer.fixedHistogram(hist_min, hist_max, hist_steps),
         "COMBINED_MEAN_COUNT": ee.Reducer.mean().combine(ee.Reducer.count(), sharedInputs=True),
         "COMBINED_COUNT_MEAN": ee.Reducer.count().combine(ee.Reducer.mean(), sharedInputs=True),
+        "COMBINED_COUNT_MEAN_UNWEIGHTED": ee.Reducer.count().combine(ee.Reducer.mean().unweighted(), sharedInputs=True),
     }
 
     if not (statistics_type.upper() in allowed_statistics.keys()):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2-RC2
+current_version = 0.17.1
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2-RC2
 commit = True
 tag = True
 


### PR DESCRIPTION
For our projects we needed to have access to more statistics in the zonal_stats function:
- COUNT, 
- MEAN_UNWEIGHTED, 
- COMBINED_COUNT_MEAN, 
- COMBINED_COUNT_MEAN_UNWEIGHTED

Let me know whether you are interested in expanding the list and whether the naming works.

Also in case you are surprised by the number of commits for such a small change:
- I tested the implementation of the countEvery reducer but it gave me errors so I rolled back.
- I also noticed that count by itself and combined with weighted mean (default) gave different results. So I tested the combination of count with unweighted mean and found that the counts then matched.
Happy to re-submit if it is an issue.