### PR TITLE
Fix `ipyleaflet.Map` broken link in `geemap.py`

### DIFF
--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -32,7 +32,7 @@ basemaps = Box(xyz_to_leaflet(), frozen_box=True)
 
 
 class Map(ipyleaflet.Map):
-    """The Map class inherits from ipyleaflet.Map. The arguments you can pass to the Map can be found at https://ipyleaflet.readthedocs.io/en/latest/api_reference/map.html. By default, the Map will add Google Maps as the basemap. Set add_google_map = False to use OpenStreetMap as the basemap.
+    """The Map class inherits from ipyleaflet.Map. The arguments you can pass to the Map can be found at https://ipyleaflet.readthedocs.io/en/latest/map_and_basemaps/map.html. By default, the Map will add Google Maps as the basemap. Set add_google_map = False to use OpenStreetMap as the basemap.
 
     Returns:
         object: ipyleaflet map object.


### PR DESCRIPTION
The link referring to `ipyleaflet.Map` documentation: https://ipyleaflet.readthedocs.io/en/latest/api_reference/map.html is broken.
The correct (updated) link is: https://ipyleaflet.readthedocs.io/en/latest/map_and_basemaps/map.html