### PR TITLE
Added support for printing objects using eerepr

### DIFF
--- a/docs/notebooks/130_print_objects.ipynb
+++ b/docs/notebooks/130_print_objects.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/130_print_objects.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "**Printing Earth Engine objects in a collapsible tree structure using eerepr**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install -U geemap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, geemap now uses [eerepr](https://github.com/aazuspan/eerepr) to print Earth Engine objects. You no longer need to used the `.getInfo()` function. Uncomment the following code block and execute it if you don't want to use eerepr for printing objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os\n",
+    "# os.environ['USE_EEREPR'] = 'False'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.Image`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = ee.Image('USGS/SRTMGL1_003')\n",
+    "image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.ImageCollection`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection = ee.ImageCollection(\"LANDSAT/LC09/C02/T1_L2\").limit(10)\n",
+    "collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.Feature`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feature = ee.FeatureCollection(\"TIGER/2018/States\").first()\n",
+    "feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.FeatureCollection`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc = ee.FeatureCollection(\"TIGER/2018/States\").limit(10)\n",
+    "fc"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -141,3 +141,4 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 127. Creating multiple legends and add them to the map ([notebook](https://geemap.org/notebooks/127_create_legend))
 128. Adding text, images, HTML, and widgets to the map ([notebook](https://geemap.org/notebooks/128_add_widget))
 129. Creating animated GIF from vector data with only one line of code ([notebook](https://geemap.org/notebooks/129_vector_to_gif))
+130. Printing Earth Engine objects without using the getInfo() function ([notebook](https://geemap.org/notebooks/130_print_objects))

--- a/examples/README.md
+++ b/examples/README.md
@@ -147,6 +147,7 @@ More video tutorials for geemap and Earth Engine are available on my [YouTube ch
 127. Creating multiple legends and add them to the map ([notebook](https://geemap.org/notebooks/127_create_legend))
 128. Adding text, images, HTML, and widgets to the map ([notebook](https://geemap.org/notebooks/128_add_widget))
 129. Creating animated GIF from vector data with only one line of code ([notebook](https://geemap.org/notebooks/129_vector_to_gif))
+130. Printing Earth Engine objects without using the getInfo() function ([notebook](https://geemap.org/notebooks/130_print_objects))
 
 ### 1. Introducing the geemap Python package for interactive mapping with Google Earth Engine
 

--- a/examples/notebooks/130_print_objects.ipynb
+++ b/examples/notebooks/130_print_objects.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://githubtocolab.com/giswqs/geemap/blob/master/examples/notebooks/130_print_objects.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open in Colab\"/></a>\n",
+    "\n",
+    "**Printing Earth Engine objects in a collapsible tree structure using eerepr**\n",
+    "\n",
+    "Uncomment the following line to install [geemap](https://geemap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install -U geemap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, geemap now uses [eerepr](https://github.com/aazuspan/eerepr) to print Earth Engine objects. You no longer need to used the `.getInfo()` function. Uncomment the following code block and execute it if you don't want to use eerepr for printing objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os\n",
+    "# os.environ['USE_EEREPR'] = 'False'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import geemap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geemap.ee_initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.Image`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = ee.Image('USGS/SRTMGL1_003')\n",
+    "image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.ImageCollection`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection = ee.ImageCollection(\"LANDSAT/LC09/C02/T1_L2\").limit(10)\n",
+    "collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.Feature`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feature = ee.FeatureCollection(\"TIGER/2018/States\").first()\n",
+    "feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print `ee.FeatureCollection`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fc = ee.FeatureCollection(\"TIGER/2018/States\").limit(10)\n",
+    "fc"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/geemap/__init__.py
+++ b/geemap/__init__.py
@@ -25,6 +25,19 @@ def use_folium():
         return False
 
 
+def _use_eerepr(token="USE_EEREPR"):
+    """Whether to use eerepr for printing Earth Engine objects.
+
+    Returns:
+        bool: True if eerepr is used for printing Earth Engine objects.
+    """
+
+    if os.environ.get(token) is None:
+        return True
+    else:
+        return False
+
+
 if use_folium():
     from .foliumap import *
 else:
@@ -40,5 +53,8 @@ else:
                 "Please restart Jupyter kernel after installation if you encounter any errors when importing geemap."
             )
         raise Exception(e)
+
+if _use_eerepr():
+    import eerepr
 
 from .report import Report

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -5553,7 +5553,7 @@ def cog_stats(url, titiler_endpoint=None, timeout=300):
     Returns:
         list: A dictionary of band statistics.
     """
-    
+
     titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     url = get_direct_url(url)
     r = requests.get(
@@ -5567,9 +5567,7 @@ def cog_stats(url, titiler_endpoint=None, timeout=300):
     return r
 
 
-def cog_info(
-    url, titiler_endpoint=None, return_geojson=False, timeout=300
-):
+def cog_info(url, titiler_endpoint=None, return_geojson=False, timeout=300):
     """Get band statistics of a Cloud Optimized GeoTIFF (COG).
 
     Args:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -259,6 +259,7 @@ nav:
           - notebooks/127_create_legend.ipynb
           - notebooks/128_add_widget.ipynb
           - notebooks/129_vector_to_gif.ipynb
+          - notebooks/130_print_objects.ipynb
     #   - miscellaneous:
     #         - notebooks/cartoee_colab.ipynb
     #         - notebooks/cartoee_colorbar.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bqplot
 colour
 earthengine-api>=0.1.304
 ee_extra>=0.0.10
+eerepr>=0.0.4
 ffmpeg-python
 folium>=0.11.0
 gdown


### PR DESCRIPTION
This PR adds support for printing Earth Engine objects using [eerepr](https://github.com/aazuspan/eerepr). The `.getInfo()` function is no longer needed to print Earth Engine objects. Simply type the object in a notebook cell to display it. Big thank you to @aazuspan for developing eerepr!

![Peek 2022-12-01 09-17](https://user-images.githubusercontent.com/5016453/205075907-3b472a35-b5d0-4e57-9cef-4dcafa1b53c7.gif)
