### PR TITLE
Fixed draw control bug #1352

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.18.3 - Dec 1, 2022
+
+**Improvement**
+
+-   Fixed draw control bug ([#1352](https://github.com/giswqs/geemap/pull/1352))
+
 ## v0.18.2 - Dec 1, 2022
 
 **New Features**

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -1283,6 +1283,8 @@ def geojson_to_ee(geo_json, geodesic=False, encoding="utf-8"):
                     geom = ee.Geometry(geo_json["geometry"])
                     radius = geo_json["properties"]["style"]["radius"]
                     geom = geom.buffer(radius)
+                else:
+                    geom = ee.Geometry(geo_json["geometry"])
             elif (
                 geo_json["geometry"]["type"] == "Point"
             ):  # Checks whether it is a point


### PR DESCRIPTION
The `geojson_to_ee` update in the previous release results in `Map.user_roi` return None. This PR fixes the bug. #1352