### PR TITLE
Fixed add_labels bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,6 @@ geemap
 
 .. image:: https://img.shields.io/badge/YouTube-Channel-red   
         :target: https://youtube.com/@giswqs
-
-.. image:: https://img.shields.io/lgtm/grade/python/g/giswqs/geemap.svg?logo=lgtm&logoWidth=18
-        :target: https://lgtm.com/projects/g/giswqs/geemap/context:python
         
 .. image:: https://img.shields.io/twitter/follow/giswqs?style=social   	
         :target: https://twitter.com/giswqs

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,6 @@
 [![image](https://pepy.tech/badge/geemap)](https://pepy.tech/project/geemap)
 [![image](https://github.com/giswqs/geemap/workflows/docs/badge.svg)](https://geemap.org)
 [![image](https://github.com/giswqs/geemap/workflows/build/badge.svg)](https://github.com/giswqs/geemap/actions?query=workflow%3Abuild)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/giswqs/geemap.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/giswqs/geemap/context:python)
 [![image](https://img.shields.io/badge/YouTube-Channel-red)](https://youtube.com/@giswqs)
 [![image](https://img.shields.io/twitter/follow/giswqs?style=social)](https://twitter.com/giswqs)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -1105,7 +1105,8 @@ class Map(ipyleaflet.Map):
                         except KeyError:
                             opacity = 1.0
                     else:
-                        opacity = layer.opacity
+                        if hasattr(layer, "opacity"):
+                            opacity = layer.opacity
 
                     layer_opacity = widgets.FloatSlider(
                         value=opacity,
@@ -1193,7 +1194,7 @@ class Map(ipyleaflet.Map):
 
                     if layer in self.geojson_layers:
                         layer_opacity.observe(layer_opacity_changed, "value")
-                    else:
+                    elif hasattr(layer, "opacity"):
                         widgets.jsdlink((layer_opacity, "value"), (layer, "opacity"))
                     hbox = widgets.HBox(
                         [layer_chk, layer_settings, layer_opacity],


### PR DESCRIPTION
This PR fixes the `add_labels()` bug reported in #1390. Labels are added to the map as a `LayerGroup`, which does not have the `visibile` or `opacity` attribute. The LayerControl breaks due to the LayerGroup. 