### PR TITLE
Pin ipywidgets version #1407

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ ipyevents
 ipyfilechooser>=0.6.0
 ipyleaflet>=0.17.0
 ipytree
+ipywidgets<8.0.0
 matplotlib
 numpy
 pandas


### PR DESCRIPTION
This PR pin the iypwidgets version to <8.0.0 as ipywidgets 8.x does not support VS Code.