### PR TITLE
Added pyperclip for auto copy to clipboard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.19.6 - Jan 23, 2023
+
+**Improvement**
+
+-   Automatically copy converted JavaScript to Python script to clipboard ([#1411](https://github.com/giswqs/geemap/issues/1411))
+
 ## v0.19.5 - Jan 19, 2023
 
 **Improvement**

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -4129,8 +4129,14 @@ def create_code_cell(code="", where="below"):
     """
 
     import base64
+    import pyperclip
 
     from IPython.display import Javascript, display
+
+    try:
+        pyperclip.copy(str(code))
+    except Exception as e:
+        pass
 
     encoded_code = (base64.b64encode(str.encode(code))).decode()
     display(

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -322,6 +322,9 @@ class Map(ipyleaflet.Map):
                 create_code_cell(contents)
                 with search_output:
                     search_output.clear_output(wait=True)
+                    print(
+                        "# The code has been copied to the clipboard. \n# Press Ctrl+V in a new cell to paste it."
+                    )
                     print(contents)
 
         import_btn.on_click(import_btn_clicked)

--- a/geemap/toolbar.py
+++ b/geemap/toolbar.py
@@ -600,8 +600,10 @@ def convert_js2py(m):
                 )
                 if len(out_lines) > 0 and len(out_lines[0].strip()) == 0:
                     out_lines = out_lines[1:]
-                text_widget.value = "".join(out_lines)
-                create_code_cell(text_widget.value)
+
+                prefix = "# The code has been copied to the clipboard. \n# Press Ctrl+V to in a code cell to paste it.\n"
+                text_widget.value = "".join([prefix] + out_lines)
+                create_code_cell("".join(out_lines))
 
         elif change["new"] == "Clear":
             text_widget.value = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ numpy
 pandas
 pillow
 pycrs
+pyperclip
 pyshp>=2.1.3
 python-box
 sankee>=0.1.0


### PR DESCRIPTION
This PR adds functionality for automatically copying converted JavaScript to Python script to the clipboard. Since Colab and JupyterLab do not support creating new code cells programmatically, this new feature allows users to simply press `Ctrl+V` to paste the code example to a new cell. 

#1411