### PR TITLE
zonal_stats_by_group patch

### DIFF
--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6885,6 +6885,7 @@ def zonal_stats_by_group(
             ee.Reducer.frequencyHistogram(),
             geometry=geometry,
             bestEffort=True,
+            crs=crs,
             scale=scale,
         )
         class_values = (

--- a/geemap/common.py
+++ b/geemap/common.py
@@ -6887,6 +6887,7 @@ def zonal_stats_by_group(
             bestEffort=True,
             crs=crs,
             scale=scale,
+            tile_scale=tile_scale
         )
         class_values = (
             ee.Dictionary(hist.get(band_name))


### PR DESCRIPTION
I noticed the function `zonal_stats_by_group` has arguments `crs` and `tile_scale` that are not used. Its sister function `zonal_stats` uses these arguments in a function call to `ee.Image.reduceRegions`, so I made this change for `zonal_stats_by_group`. I assume this was an inadvertent omission, not a deliberate decision, since these arguments are documented as if they should have an effect.

This pull request simply ensures the two arguments are actually used and only adds two words of code!