### PR TITLE
Fix ipywidgets error

### DIFF
--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -1,4 +1,5 @@
 import os
+import ipykernel.ipkernel
 from .common import *
 from .osm import *
 from .geemap import basemaps

--- a/geemap/foliumap.py
+++ b/geemap/foliumap.py
@@ -6,6 +6,7 @@ import ee
 import folium
 from box import Box
 from folium import plugins
+import ipykernel.ipkernel
 
 from branca.element import Figure, JavascriptLink, MacroElement
 from folium.elements import JSCSSMixin

--- a/geemap/geemap.py
+++ b/geemap/geemap.py
@@ -12,6 +12,7 @@ import ee
 import ipyevents
 import ipyleaflet
 import ipywidgets as widgets
+import ipykernel.ipkernel
 from box import Box
 from bqplot import pyplot as plt
 from ipyfilechooser import FileChooser

--- a/geemap/heremap.py
+++ b/geemap/heremap.py
@@ -9,6 +9,7 @@ import json
 import random
 import requests
 import ipywidgets as widgets
+import ipykernel.ipkernel
 from box import Box
 from .basemaps import xyz_to_heremap
 from .common import *

--- a/geemap/kepler.py
+++ b/geemap/kepler.py
@@ -3,6 +3,7 @@ import os
 import sys
 import requests
 import ipywidgets as widgets
+import ipykernel.ipkernel
 import pandas as pd
 from IPython.display import display, HTML
 from .common import *

--- a/geemap/plotlymap.py
+++ b/geemap/plotlymap.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 import ipywidgets as widgets
+import ipykernel.ipkernel
 from .basemaps import xyz_to_plotly
 from .common import *
 from .osm import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ geocoder
 geojson
 ipyevents
 ipyfilechooser>=0.6.0
+ipykernel
 ipyleaflet>=0.17.0
 ipytree
 ipywidgets<8.0.0


### PR DESCRIPTION
ipywidgets v8.05 no loner requires ipykernel. It breaks some downstream packages. This PR adds `import ipykernel.ipkernel` to each module. 
https://github.com/jupyter-widgets/ipywidgets/issues/3729