### PR TITLE
lit_widget.ts: Remove incorrect override.

### DIFF
--- a/js/lit_widget.ts
+++ b/js/lit_widget.ts
@@ -13,7 +13,7 @@ export abstract class LitWidget<
         keyof SubclassType | null
     >;
 
-    override onCustomMessage?(_msg: any): void {}
+    onCustomMessage?(_msg: any): void {}
 
     viewNameToModelName(): Map<keyof SubclassType | null, keyof ModelType> {
         return reverseMap(this.modelNameToViewName());


### PR DESCRIPTION
> js/lit_widget.ts:27:14 - error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'LitElement'.

Fixes a mistake in https://github.com/gee-community/geemap/commit/aafc8ffa347b9cf6bae9054a55602a69283f8e5a