### PR TITLE
pyproject.toml: Update minimum ee client ver to 1.5.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "anywidget",
     "bqplot",
-    "earthengine-api>=1.0.0",
+    "earthengine-api>=1.5.12",
     "eerepr>=0.1.0",
     "folium>=0.17.0",
     "geocoder",


### PR DESCRIPTION
This change is needed because of this change:

https://github.com/google/earthengine-api/commit/27d6d9eaf40f8e4894ca5b7648d24646b148f36d

> Add https://www.googleapis.com/auth/drive scope to the default OAuth scopes