### PR TITLE
pyproject.toml: Add `requests` to dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pyperclip",
     "pyshp>=2.3.1",
     "python-box",
+    "requests",
     "scooby",
 ]
 


### PR DESCRIPTION
common.py has required requests for a long time.

This issue was spotted by @naschmitz in reviewing https://github.com/gee-community/geemap/pull/2346