### PR TITLE
test_conversion.py: Fix test_find_matching_bracket_not_at_start

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -50,17 +50,17 @@ class TestConversion(unittest.TestCase):
         self.assertEqual(char_index, -1)
 
     def test_find_matching_bracket_not_at_start(self):
-        input = textwrap.dedent(
+        source = textwrap.dedent(
             """\
             [
               {
-              }
+                }
             ]
         """
-        )
-        line_index, char_index = conversion.find_matching_bracket(input, 3, 4)
-        self.assertEqual(line_index, 8)
-        self.assertEqual(char_index, 0)
+        ).splitlines()
+        line_index, char_index = conversion.find_matching_bracket(source, 1, 2)
+        self.assertEqual(line_index, 2)
+        self.assertEqual(char_index, 4)
 
     def test_format_params_simple(self):
         line = "min: 0"


### PR DESCRIPTION
* Should have deindented and done splitlines!
* Also, don't reused the already existing `input` symbol