### PR TITLE
datasets.py: Cleanup

### DIFF
--- a/geemap/datasets.py
+++ b/geemap/datasets.py
@@ -69,7 +69,7 @@ def get_data_list() -> list:
 
 
 def get_geemap_data_list() -> list[str]:
-    """Gets the list of the public datasets from GEE users."""
+    """Returns the list of the public datasets from GEE users."""
     extra_ids = [
         "countries",
         "us_states",


### PR DESCRIPTION
* Remove "Returns" section when the doc string starts with "Returns"
* Remove type info from doc string when there are type annotations
* Improved the type annotations
* Removed some redundant try / except wraps
* Fix text to 88 columns when possible