### PR TITLE
deck.py: Cleanup

### DIFF
--- a/geemap/deck.py
+++ b/geemap/deck.py
@@ -133,7 +133,7 @@ class Map(pdk.Deck):
     def add_ee_layer(
         self,
         ee_object,
-        # TODO(schwehr): No not use a mutable ubject as the default.
+        # TODO(schwehr): Do not use a mutable object as the default.
         vis_params: dict[Any, Any] = {},
         name: str | None = None,
         **kwargs,


### PR DESCRIPTION
* Add some type annotations
* Remove types from doc string when type annotation is preent
* Add a TODO about `type` and `id` already existing and needing to be renamed
* Fit to 88 columns